### PR TITLE
fix for config not showing up in UI

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,5 +1,5 @@
   {
-    "pluginAlias": "Tuya",
+    "pluginAlias": "TuyaLan",
     "pluginType": "platform",
     "singular": true,
     "headerDisplay": "<p align='center'><img height='60px' src='https://user-images.githubusercontent.com/3979615/78354049-dc7ff780-75f6-11ea-8026-2f8bf81d8331.png'></p>\n\nBefore using the Tuya plugin you need to discover your devices by following [these instructions](https://github.com/AMoo-Miki/homebridge-tuya-lan/wiki/Setup-Instructions).\n\n",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-tuya-local",
 
-  "version": "3.0.2",
+  "version": "3.0.3",
 
   "description": "🏠 Control Tuya Accessories Locally with Homebridge",
   "main": "index.js",


### PR DESCRIPTION
this fixes the homebridge-config-ui-x  issue where the config created by the UI doesnt use the right platform name, and vice versa the manually created config doesnt show up in the ui due to the name change. this is now fixed.

