### PR TITLE
Homebridge 2.0 / hap-nodejs 2.x compatibility

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,8 +7,8 @@ All notable changes to this project will be documented in this file. This projec
 Compatibility pass for **Homebridge 2.0 / hap-nodejs 2.x**. Without these fixes the plugin silently fails to register any accessory on Homebridge 2.x.
 
 * [+] `index.js`: resolve `Categories` from `homebridge.hap.Categories` (1.x had it under `homebridge.hap.Accessory.Categories`). Fixes `TypeError: Cannot read properties of undefined (reading 'LIGHTBULB')` thrown from every accessory class's `getCategory(Categories)`.
-* [+] `index.js`: handle the `Characteristic.Perms.WRITE`/`READ` → `PAIRED_WRITE`/`PAIRED_READ` rename in the cached-accessory "unreachable" code path. Fixes `TypeError: Cannot read properties of undefined (reading 'WRITE')` on child-bridge restart with cached accessories.
-* [+] `lib/EnergyCharacteristics.js`: same `Perms.READ` → `PAIRED_READ` fallback for the custom Eve energy characteristics.
+* [+] `index.js`: capture the `Perms` enum from `hap.Perms` (hap-nodejs 2.x) with a fallback to the legacy `Characteristic.Perms` (1.x), and use the captured reference in the cached-accessory "unreachable" code path. Also handles the `WRITE`/`READ` → `PAIRED_WRITE`/`PAIRED_READ` rename. Fixes `TypeError: Cannot read properties of undefined (reading 'PAIRED_WRITE')` (and the prior `'WRITE'`/`'READ'` variants) on child-bridge restart with cached accessories.
+* [+] `lib/EnergyCharacteristics.js`: accept `Perms` as a second argument from the caller, with the same fallback, for the custom Eve energy characteristics.
 * [+] `lib/BaseAccessory.js` and `index.js`: replaced the four bare-callable `this.log(...)` invocations (`identify`, `Connected to`, `Ready to handle`, "No devices found") with `this.log.info(...)`. Homebridge 2.0's Logger isn't callable as a function; the bare form threw inside the `'connect'` event handler, tearing down the socket immediately after a successful TCP handshake.
 * [+] `package.json`: bumped `engines` to `homebridge: "^1.6.0 || ^2.0.0"` and `node: "^18.20.4 || ^20.15.1 || ^22 || ^24"`. Both fall in line with the Homebridge 2.0 Node baseline.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. This project uses [semantic versioning](https://semver.org/).
 
+## 3.2.0 (2026-05-06)
+
+Compatibility pass for **Homebridge 2.0 / hap-nodejs 2.x**. Without these fixes the plugin silently fails to register any accessory on Homebridge 2.x.
+
+* [+] `index.js`: resolve `Categories` from `homebridge.hap.Categories` (1.x had it under `homebridge.hap.Accessory.Categories`). Fixes `TypeError: Cannot read properties of undefined (reading 'LIGHTBULB')` thrown from every accessory class's `getCategory(Categories)`.
+* [+] `index.js`: handle the `Characteristic.Perms.WRITE`/`READ` → `PAIRED_WRITE`/`PAIRED_READ` rename in the cached-accessory "unreachable" code path. Fixes `TypeError: Cannot read properties of undefined (reading 'WRITE')` on child-bridge restart with cached accessories.
+* [+] `lib/EnergyCharacteristics.js`: same `Perms.READ` → `PAIRED_READ` fallback for the custom Eve energy characteristics.
+* [+] `lib/BaseAccessory.js` and `index.js`: replaced the four bare-callable `this.log(...)` invocations (`identify`, `Connected to`, `Ready to handle`, "No devices found") with `this.log.info(...)`. Homebridge 2.0's Logger isn't callable as a function; the bare form threw inside the `'connect'` event handler, tearing down the socket immediately after a successful TCP handshake.
+* [+] `package.json`: bumped `engines` to `homebridge: "^1.6.0 || ^2.0.0"` and `node: "^18.20.4 || ^20.15.1 || ^22 || ^24"`. Both fall in line with the Homebridge 2.0 Node baseline.
+
+All fallbacks are runtime-conditional, so the plugin continues to work on Homebridge 1.x.
+
 ## 2.0.1 (2021-03-25)
 This update includes the following changes:
 

--- a/index.js
+++ b/index.js
@@ -55,10 +55,11 @@ const CLASS_DEF = {
 let Characteristic, PlatformAccessory, Service, Categories, AdaptiveLightingController, UUID;
 
 module.exports = function(homebridge) {
-    ({
-        platformAccessory: PlatformAccessory,
-        hap: {Characteristic, Service, AdaptiveLightingController, Accessory: {Categories}, uuid: UUID}
-    } = homebridge);
+    PlatformAccessory = homebridge.platformAccessory;
+    ({Characteristic, Service, AdaptiveLightingController, uuid: UUID} = homebridge.hap);
+    // hap-nodejs 1.x exposed Categories under hap.Accessory.Categories; 2.x (Homebridge 2.0)
+    // moved it to hap.Categories. Support both so the plugin works across versions.
+    Categories = homebridge.hap.Categories || (homebridge.hap.Accessory && homebridge.hap.Accessory.Categories);
 
     homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, TuyaLan, true);
 };
@@ -71,7 +72,7 @@ class TuyaLan {
         this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(this.api.hap.Characteristic);
 
         if(!this.config || !this.config.devices) {
-            this.log("No devices found. Check that you have specified them in your config.json file.");
+            this.log.info("No devices found. Check that you have specified them in your config.json file.");
             return false;
         }
 
@@ -197,13 +198,17 @@ class TuyaLan {
         // also checks null objects or empty config - this._expectedUUIDs
         if (accessory instanceof PlatformAccessory && this._expectedUUIDs && this._expectedUUIDs.includes(accessory.UUID)) {
             this.cachedAccessories.set(accessory.UUID, accessory);
+            // hap-nodejs 1.x used Perms.WRITE/READ; 2.x (Homebridge 2.0) renamed them to
+            // PAIRED_WRITE/PAIRED_READ. Resolve at runtime so this works on either.
+            const writePerm = Characteristic.Perms.PAIRED_WRITE || Characteristic.Perms.WRITE;
+            const notifyPerm = Characteristic.Perms.NOTIFY;
             accessory.services.forEach(service => {
                 if (service.UUID === Service.AccessoryInformation.UUID) return;
                 service.characteristics.some(characteristic => {
                     if (!characteristic.props ||
                         !Array.isArray(characteristic.props.perms) ||
                         characteristic.props.perms.length !== 3 ||
-                        !(characteristic.props.perms.includes(Characteristic.Perms.WRITE) && characteristic.props.perms.includes(Characteristic.Perms.NOTIFY))
+                        !(characteristic.props.perms.includes(writePerm) && characteristic.props.perms.includes(notifyPerm))
                     ) return;
 
                     this.log.info('Marked %s unreachable by faulting Service.%s.%s', accessory.displayName, service.displayName, characteristic.displayName);

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ const CLASS_DEF = {
     oildiffuser: OilDiffuserAccessory
 };
 
-let Characteristic, PlatformAccessory, Service, Categories, AdaptiveLightingController, UUID;
+let Characteristic, PlatformAccessory, Service, Categories, AdaptiveLightingController, UUID, Perms;
 
 module.exports = function(homebridge) {
     PlatformAccessory = homebridge.platformAccessory;
@@ -60,6 +60,9 @@ module.exports = function(homebridge) {
     // hap-nodejs 1.x exposed Categories under hap.Accessory.Categories; 2.x (Homebridge 2.0)
     // moved it to hap.Categories. Support both so the plugin works across versions.
     Categories = homebridge.hap.Categories || (homebridge.hap.Accessory && homebridge.hap.Accessory.Categories);
+    // hap-nodejs 1.x exposed the Perms enum as a static on Characteristic; 2.x lifted it
+    // to a top-level export on hap. Capture from either location.
+    Perms = homebridge.hap.Perms || (Characteristic && Characteristic.Perms);
 
     homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, TuyaLan, true);
 };
@@ -69,7 +72,7 @@ class TuyaLan {
         [this.log, this.config, this.api] = [...props];
 
         this.cachedAccessories = new Map();
-        this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(this.api.hap.Characteristic);
+        this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(this.api.hap.Characteristic, Perms);
 
         if(!this.config || !this.config.devices) {
             this.log.info("No devices found. Check that you have specified them in your config.json file.");
@@ -200,8 +203,8 @@ class TuyaLan {
             this.cachedAccessories.set(accessory.UUID, accessory);
             // hap-nodejs 1.x used Perms.WRITE/READ; 2.x (Homebridge 2.0) renamed them to
             // PAIRED_WRITE/PAIRED_READ. Resolve at runtime so this works on either.
-            const writePerm = Characteristic.Perms.PAIRED_WRITE || Characteristic.Perms.WRITE;
-            const notifyPerm = Characteristic.Perms.NOTIFY;
+            const writePerm = Perms.PAIRED_WRITE || Perms.WRITE;
+            const notifyPerm = Perms.NOTIFY;
             accessory.services.forEach(service => {
                 if (service.UUID === Service.AccessoryInformation.UUID) return;
                 service.characteristics.some(characteristic => {

--- a/lib/BaseAccessory.js
+++ b/lib/BaseAccessory.js
@@ -8,16 +8,16 @@ class BaseAccessory {
 
         this.accessory.on('identify', function(paired, callback) {
             // ToDo: Add identification routine
-            this.log("%s - identify", this.device.context.name);
+            this.log.info("%s - identify", this.device.context.name);
             callback();
         }.bind(this));
 
         this.device.once('connect', () => {
-            this.log('Connected to', this.device.context.name);
+            this.log.info('Connected to %s', this.device.context.name);
         });
 
         this.device.once('change', () => {
-            this.log(`Ready to handle ${this.device.context.name} (${this.device.context.type}:${this.device.context.version}) with signature ${JSON.stringify(this.device.state)}`);
+            this.log.info(`Ready to handle ${this.device.context.name} (${this.device.context.type}:${this.device.context.version}) with signature ${JSON.stringify(this.device.state)}`);
 
             this._registerCharacteristics(this.device.state);
         });

--- a/lib/EnergyCharacteristics.js
+++ b/lib/EnergyCharacteristics.js
@@ -1,6 +1,10 @@
 // Thanks to homebridge-tplink-smarthome
 
 module.exports = function(Characteristic) {
+    // hap-nodejs 1.x exposed Perms.READ; 2.x (Homebridge 2.0) renamed it to PAIRED_READ.
+    // Resolve at runtime so this works on either.
+    const READ_PERM = Characteristic.Perms.PAIRED_READ || Characteristic.Perms.READ;
+
     class EnergyCharacteristic extends Characteristic {
         constructor(displayName, UUID, props) {
             super(displayName, UUID);
@@ -8,7 +12,7 @@ module.exports = function(Characteristic) {
                 format: Characteristic.Formats.FLOAT,
                 minValue: 0,
                 maxValue: 65535,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+                perms: [READ_PERM, Characteristic.Perms.NOTIFY]
             }, props));
             this.value = this.getDefaultValue();
         }

--- a/lib/EnergyCharacteristics.js
+++ b/lib/EnergyCharacteristics.js
@@ -1,9 +1,12 @@
 // Thanks to homebridge-tplink-smarthome
 
-module.exports = function(Characteristic) {
-    // hap-nodejs 1.x exposed Perms.READ; 2.x (Homebridge 2.0) renamed it to PAIRED_READ.
-    // Resolve at runtime so this works on either.
-    const READ_PERM = Characteristic.Perms.PAIRED_READ || Characteristic.Perms.READ;
+module.exports = function(Characteristic, Perms) {
+    // hap-nodejs 1.x exposed the Perms enum as a static on Characteristic; 2.x lifted it
+    // to a top-level export on hap. Accept it from the caller, fall back to the legacy
+    // location for callers that don't pass it.
+    Perms = Perms || (Characteristic && Characteristic.Perms);
+    // hap-nodejs 1.x used Perms.READ; 2.x (Homebridge 2.0) renamed it to PAIRED_READ.
+    const READ_PERM = Perms.PAIRED_READ || Perms.READ;
 
     class EnergyCharacteristic extends Characteristic {
         constructor(displayName, UUID, props) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tuya-local",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "description": "🏠 Control Tuya Accessories Locally with Homebridge",
   "main": "index.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "lan"
   ],
   "engines": {
-    "homebridge": ">=0.4.0",
-    "node": ">=8.6.0"
+    "homebridge": "^1.6.0 || ^2.0.0",
+    "node": "^18.20.4 || ^20.15.1 || ^22 || ^24"
   }
 }


### PR DESCRIPTION
## Summary

Compatibility pass so the plugin runs on Homebridge 2.0 / hap-nodejs 2.x. Without these fixes the plugin throws inside the `discover` handler on HB 2.0 and silently fails to register any accessory — the device gets discovered, then nothing else happens (no `Connected to`, no error). All fallbacks are runtime-conditional, so the plugin keeps working on Homebridge 1.x.

- `index.js`: resolve `Categories` from `homebridge.hap.Categories` (1.x had it under `homebridge.hap.Accessory.Categories`). Without this, every accessory class's `getCategory(Categories)` throws `Cannot read properties of undefined (reading 'LIGHTBULB')`.
- `index.js` + `lib/EnergyCharacteristics.js`: resolve `Characteristic.Perms.PAIRED_WRITE` / `PAIRED_READ` (renamed from `WRITE` / `READ` in hap-nodejs 2.x), with fallback. Affects the cached-accessory "unreachable" path and the Eve-style energy characteristics.
- `lib/BaseAccessory.js` + `index.js`: four bare-callable `this.log(...)` sites (`identify`, `Connected to`, `Ready to handle`, "No devices found") changed to `this.log.info(...)`. The Homebridge 2.0 Logger isn't callable as a function; the bare form threw inside the `'connect'` handler and tore down the socket immediately after a successful TCP handshake.
- `package.json`: bumped to v3.2.0; `engines.homebridge` → `^1.6.0 || ^2.0.0`; `engines.node` → `^18.20.4 || ^20.15.1 || ^22 || ^24` (matches the HB 2.0 Node baseline).

Scope is intentionally narrow — only the v2 compat shims plus the engine bump. Existing accessory logic, the noisy "Failed to parse" discovery error, and characteristic-validation cleanups are left for separate PRs.

## Test plan

- [x] Verified on Homebridge 2.0.1 / Node 24.12 / hap-nodejs 2.1.5 with a v3.3 Tuya floodlight (`TWLight`): plugin loads, discovers, opens the TCP session, registers the lightbulb, characteristics populate from device state, on/off and brightness work end-to-end.
- [ ] Smoke test on Homebridge 1.x to confirm the runtime fallbacks don't regress 1.x users.
- [ ] Smoke test other accessory types (`RGBTWLight`, `Outlet`, etc.) — the changes are in shared paths so all types should benefit, but a second pair of eyes welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)