### PR TITLE
Accept numeric mode values in AirConditionerAccessory

### DIFF
--- a/lib/AirConditionerAccessory.js
+++ b/lib/AirConditionerAccessory.js
@@ -10,26 +10,14 @@ class AirConditionerAccessory extends BaseAccessory {
     constructor(...props) {
         super(...props);
 
-        this.cmdCool = 'COOL';
-        if (this.device.context.cmdCool) {
-            if (/^c[a-z]+$/i.test(this.device.context.cmdCool)) this.cmdCool = ('' + this.device.context.cmdCool).trim();
-            else throw new Error('The cmdCool doesn\'t appear to be valid: ' + this.device.context.cmdCool);
-        }
 
-        this.cmdHeat = 'HEAT';
-        if (this.device.context.cmdHeat) {
-            if (/^h[a-z]+$/i.test(this.device.context.cmdHeat)) this.cmdHeat = ('' + this.device.context.cmdHeat).trim();
-            else throw new Error('The cmdHeat doesn\'t appear to be valid: ' + this.device.context.cmdHeat);
-        }
 
-        this.cmdAuto = 'AUTO';
-        if (this.device.context.cmdAuto) {
-            if (/^a[a-z]+$/i.test(this.device.context.cmdAuto)) this.cmdAuto = ('' + this.device.context.cmdAuto).trim();
-            else throw new Error('The cmdAuto doesn\'t appear to be valid: ' + this.device.context.cmdAuto);
-        }
+        this.cmdCool = this.device.context.cmdCool ? String(this.device.context.cmdCool).trim() : 'COOL';
+        this.cmdHeat = this.device.context.cmdHeat ? String(this.device.context.cmdHeat).trim() : 'HEAT';
+        this.cmdAuto = this.device.context.cmdAuto ? String(this.device.context.cmdAuto).trim() : 'AUTO';
 
-        // Disabling auto mode because I have not found a Tuya device config that has a temperature range for AUTO
-        this.device.context.noAuto = true;
+        // Default noAuto to true unless explicitly configured
+        if (this.device.context.noAuto === undefined) this.device.context.noAuto = true;        
 
         if (!this.device.context.noRotationSpeed) {
             const fanSpeedSteps = (this.device.context.fanSpeedSteps && isFinite(this.device.context.fanSpeedSteps) && this.device.context.fanSpeedSteps > 0 && this.device.context.fanSpeedSteps < 100) ? this.device.context.fanSpeedSteps : 100;

--- a/lib/AirConditionerAccessory.js
+++ b/lib/AirConditionerAccessory.js
@@ -10,8 +10,6 @@ class AirConditionerAccessory extends BaseAccessory {
     constructor(...props) {
         super(...props);
 
-
-
         this.cmdCool = this.device.context.cmdCool ? String(this.device.context.cmdCool).trim() : 'COOL';
         this.cmdHeat = this.device.context.cmdHeat ? String(this.device.context.cmdHeat).trim() : 'HEAT';
         this.cmdAuto = this.device.context.cmdAuto ? String(this.device.context.cmdAuto).trim() : 'AUTO';


### PR DESCRIPTION
# PR: Accept numeric mode values in AirConditionerAccessory

## Context

The `AirConditionerAccessory.js` constructor validates `cmdCool`, `cmdHeat`, and `cmdAuto` config values using regexes that only accept alphabetic text starting with specific letters (e.g., `/^c[a-z]+$/i` for cool). Many Tuya devices — particularly Hyundai portable ACs and other OEM units — use numeric string values for modes (e.g., `"1"` = cool, `"2"` = heat, `"3"` = dehumidify, `"5"` = fan). The plugin crashes with these devices.

## File to Change

**`lib/AirConditionerAccessory.js`** — constructor only.

### Before (lines 12–28):

```javascript
        this.cmdCool = 'COOL';
        if (this.device.context.cmdCool) {
            if (/^c[a-z]+$/i.test(this.device.context.cmdCool)) this.cmdCool = ('' + this.device.context.cmdCool).trim();
            else throw new Error('The cmdCool doesn\'t appear to be valid: ' + this.device.context.cmdCool);
        }

        this.cmdHeat = 'HEAT';
        if (this.device.context.cmdHeat) {
            if (/^h[a-z]+$/i.test(this.device.context.cmdHeat)) this.cmdHeat = ('' + this.device.context.cmdHeat).trim();
            else throw new Error('The cmdHeat doesn\'t appear to be valid: ' + this.device.context.cmdHeat);
        }

        this.cmdAuto = 'AUTO';
        if (this.device.context.cmdAuto) {
            if (/^a[a-z]+$/i.test(this.device.context.cmdAuto)) this.cmdAuto = ('' + this.device.context.cmdAuto).trim();
            else throw new Error('The cmdAuto doesn\'t appear to be valid: ' + this.device.context.cmdAuto);
        }

        // Disabling auto mode because I have not found a Tuya device config that has a temperature range for AUTO
        this.device.context.noAuto = true;
```

### After:

```javascript
        this.cmdCool = this.device.context.cmdCool ? String(this.device.context.cmdCool).trim() : 'COOL';
        this.cmdHeat = this.device.context.cmdHeat ? String(this.device.context.cmdHeat).trim() : 'HEAT';
        this.cmdAuto = this.device.context.cmdAuto ? String(this.device.context.cmdAuto).trim() : 'AUTO';

        // Default noAuto to true unless explicitly configured
        if (this.device.context.noAuto === undefined) this.device.context.noAuto = true;
```

## Why This Fix

- **Backwards-compatible**: Existing configs with text values ("COOL", "Cooling") still work
- **Supports numeric modes**: Tuya OEM devices (Hyundai, Goldair, etc.) that use "1", "2", "3" for mode DPS now work
- **No crash**: Removes the throwing validation — the mode value is the device's own language, not ours to validate
- **noAuto flexibility**: Allows users to explicitly enable auto mode if their device supports it

## PR Description

---

**Title:** `fix: accept numeric mode values in AirConditioner accessory`

**Body:**

```markdown
## Problem

Many Tuya OEM air conditioners (Hyundai, Goldair, and other white-label brands) use numeric string values for their mode DPS rather than text like "COOL" or "HEAT". For example:

- `"1"` = cool
- `"2"` = heat  
- `"3"` = dehumidify
- `"5"` = fan only

The current constructor validates `cmdCool`/`cmdHeat`/`cmdAuto` with regexes that only accept alphabetic text starting with specific letters. This causes the plugin to crash with:

```
Error: The cmdCool doesn't appear to be valid: 1
```

## Fix

Replace the regex validation with simple string coercion. The mode value is sent directly to the device as a DPS command — the plugin shouldn't restrict what values are valid since that's device-specific.

## Tested with

- Hyundai HYD14KPACWA/HYD18KPACWA (modes: "1"=cool, "2"=heat, "3"=dehumidify, "5"=fan)
- Hyundai Portable AC Mini (modes: "1"=cool, "3"=dehumidify, "5"=fan)
- Tuya protocol v3.4

## Config example

```json
{
  "name": "Portable AC",
  "type": "AirConditioner",
  "id": "...",
  "key": "...",
  "ip": "192.168.1.154",
  "version": "3.4",
  "dpMode": 101,
  "cmdCool": "1",
  "cmdHeat": "2",
  "noSwing": false,
  "minTemperature": 16,
  "maxTemperature": 32
}
```

## Breaking changes

None. Existing text-based configs continue to work exactly as before.
```

---

## Verification

After submitting, the maintainer can verify by:
1. Configuring any device with `"cmdCool": "1"` — plugin should start without error
2. Existing configs with `"cmdCool": "COOL"` still work unchanged
