### PR TITLE
Patch for Homebridge 2.0 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ class TuyaLan {
                     if (!characteristic.props ||
                         !Array.isArray(characteristic.props.perms) ||
                         characteristic.props.perms.length !== 3 ||
-                        !(characteristic.props.perms.includes(Characteristic.Perms.WRITE) && characteristic.props.perms.includes(Characteristic.Perms.NOTIFY))
+                        !(characteristic.props.perms.includes(Characteristic.Perms.PAIRED_WRITE) && characteristic.props.perms.includes(Characteristic.Perms.NOTIFY))
                     ) return;
 
                     this.log.info('Marked %s unreachable by faulting Service.%s.%s', accessory.displayName, service.displayName, characteristic.displayName);

--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ class TuyaLan {
                     if (!characteristic.props ||
                         !Array.isArray(characteristic.props.perms) ||
                         characteristic.props.perms.length !== 3 ||
-                        !(characteristic.props.perms.includes(api.hap.Perms.PAIRED_WRITE) && characteristic.props.perms.includes(api.hap.Perms.NOTIFY))
+                        !(characteristic.props.perms.includes(this.api.hap.Perms.PAIRED_WRITE) && characteristic.props.perms.includes(this.api.hap.Perms.NOTIFY))
                     ) return;
 
                     this.log.info('Marked %s unreachable by faulting Service.%s.%s', accessory.displayName, service.displayName, characteristic.displayName);

--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ class TuyaLan {
                     if (!characteristic.props ||
                         !Array.isArray(characteristic.props.perms) ||
                         characteristic.props.perms.length !== 3 ||
-                        !(characteristic.props.perms.includes(Characteristic.Perms.PAIRED_WRITE) && characteristic.props.perms.includes(Characteristic.Perms.NOTIFY))
+                        !(characteristic.props.perms.includes(api.hap.Perms.PAIRED_WRITE) && characteristic.props.perms.includes(api.hap.Perms.NOTIFY))
                     ) return;
 
                     this.log.info('Marked %s unreachable by faulting Service.%s.%s', accessory.displayName, service.displayName, characteristic.displayName);

--- a/index.js
+++ b/index.js
@@ -52,12 +52,12 @@ const CLASS_DEF = {
     oildiffuser: OilDiffuserAccessory
 };
 
-let Characteristic, PlatformAccessory, Service, Categories, AdaptiveLightingController, UUID;
+let Characteristic, PlatformAccessory, Service, Categories, AdaptiveLightingController, UUID, Perms;
 
 module.exports = function(homebridge) {
     ({
         platformAccessory: PlatformAccessory,
-        hap: {Characteristic, Service, AdaptiveLightingController, Accessory: {Categories}, uuid: UUID}
+        hap: {Characteristic, Service, AdaptiveLightingController, Categories, Perms, uuid: UUID}
     } = homebridge);
 
     homebridge.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, TuyaLan, true);
@@ -68,7 +68,7 @@ class TuyaLan {
         [this.log, this.config, this.api] = [...props];
 
         this.cachedAccessories = new Map();
-        this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(this.api.hap.Characteristic);
+        this.api.hap.EnergyCharacteristics = require('./lib/EnergyCharacteristics')(this.api.hap.Characteristic, this.api.hap.Perms);
 
         if(!this.config || !this.config.devices) {
             this.log("No devices found. Check that you have specified them in your config.json file.");
@@ -203,7 +203,7 @@ class TuyaLan {
                     if (!characteristic.props ||
                         !Array.isArray(characteristic.props.perms) ||
                         characteristic.props.perms.length !== 3 ||
-                        !(characteristic.props.perms.includes(this.api.hap.Perms.PAIRED_WRITE) && characteristic.props.perms.includes(this.api.hap.Perms.NOTIFY))
+                        !(characteristic.props.perms.includes(Perms.PAIRED_WRITE) && characteristic.props.perms.includes(Perms.EVENTS))
                     ) return;
 
                     this.log.info('Marked %s unreachable by faulting Service.%s.%s', accessory.displayName, service.displayName, characteristic.displayName);

--- a/lib/EnergyCharacteristics.js
+++ b/lib/EnergyCharacteristics.js
@@ -1,6 +1,6 @@
 // Thanks to homebridge-tplink-smarthome
 
-module.exports = function(Characteristic) {
+module.exports = function(Characteristic, Perms) {
     class EnergyCharacteristic extends Characteristic {
         constructor(displayName, UUID, props) {
             super(displayName, UUID);
@@ -8,7 +8,7 @@ module.exports = function(Characteristic) {
                 format: Characteristic.Formats.FLOAT,
                 minValue: 0,
                 maxValue: 65535,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+                perms: [Perms.PAIRED_READ, Perms.EVENTS]
             }, props));
             this.value = this.getDefaultValue();
         }


### PR DESCRIPTION
Fix breaking enum references required for Homebridge 2.0.
- Destructure Categories from hap directly (moved out of hap.Accessory in HB2)
- Destructure Perms from hap at module level for consistent access
- Replace deprecated Characteristic.Perms.* with Perms.PAIRED_READ,
  Perms.PAIRED_WRITE, and Perms.EVENTS in index.js and EnergyCharacteristics
- Pass Perms to EnergyCharacteristics factory