### PR TITLE
fix: don't crash Homebridge on HMAC mismatch in 3.4 message handler

### DIFF
--- a/lib/TuyaAccessory.js
+++ b/lib/TuyaAccessory.js
@@ -517,7 +517,11 @@ class TuyaAccessory extends EventEmitter {
         const computedCrc = hmac(task.msg.slice(0, len - 0x24), this.session_key ?? this.context.key).toString('hex');
 
         if (expectedCrc !== computedCrc) {
-            throw new Error(`HMAC mismatch: expected ${expectedCrc}, was ${computedCrc}. ${task.msg.toString('hex')}`);
+            // A mismatch here almost always means the local key is wrong (e.g. the
+            // device was re-paired). Throwing would crash the whole Homebridge
+            // process from inside the message queue, so log and drop the packet.
+            this.log.error(`HMAC mismatch from ${this.context.name}; is the device key correct? expected ${expectedCrc}, was ${computedCrc}. ${task.msg.toString('hex')}`);
+            return callback();
         }
 
         let decryptedMsg;
@@ -558,7 +562,8 @@ class TuyaAccessory extends EventEmitter {
             const calcLocalHmac =  hmac(this._tmpLocalKey, this.session_key ?? this.context.key).toString('hex')
             const expLocalHmac = parsedPayload.slice(16, 16 + 32).toString('hex')
             if (expLocalHmac !== calcLocalHmac) {
-                throw new Error(`HMAC mismatch(keys): expected ${expLocalHmac}, was ${calcLocalHmac}. ${parsedPayload.toString('hex')}`);
+                this.log.error(`HMAC mismatch(keys) from ${this.context.name}; is the device key correct? expected ${expLocalHmac}, was ${calcLocalHmac}. ${parsedPayload.toString('hex')}`);
+                return callback();
             }
             const payload = {
                 data: hmac(this._tmpRemoteKey, this.context.key),


### PR DESCRIPTION
## Problem

When the configured local key doesn't match the device's actual key, the 3.4 message handler throws from inside the async message queue:

```
Error: HMAC mismatch: expected ..., was ...
    at TuyaAccessory._msgHandler_3_4 (lib/TuyaAccessory.js:520:19)
    at async/dist/async.js:3983:13
```

This is an uncaught exception, so it takes down the **entire Homebridge process** — including every other accessory on the bridge.

A wrong key is a routine occurrence with Tuya devices: every factory reset / re-pair regenerates the local key, so anyone whose device got reset (or who mistypes the key) gets a crash-looping Homebridge instead of an error message. The same applies to the session-key negotiation HMAC check a few lines below.

It also affects protocol version detection against 3.3 devices: some 3.3 firmware answers a 3.4 session-negotiation (cmd 3) with an error packet in valid 55aa framing, which lands in this handler and crashes rather than failing gracefully.

## Fix

Log a clear error pointing at the likely cause ("is the device key correct?") and drop the packet, in both the general 3.4 message path and the session-key negotiation path. The existing connection/retry machinery then handles reconnection as usual.

Verified against a real device (XMCosy RGBCW string lights, protocol 3.3, deliberately wrong key): previously the process died on the first response packet; with this change it logs the mismatch and keeps running.