### PR TITLE
fix: update Saturation characteristic with saturation, not hue

### DIFF
--- a/lib/RGBTWLightAccessory.js
+++ b/lib/RGBTWLightAccessory.js
@@ -126,7 +126,7 @@ class RGBTWLightAccessory extends BaseAccessory {
                         if (oldColor.b !== newColor.b) characteristicBrightness.updateValue(newColor.b);
                         if (oldColor.h !== newColor.h) characteristicHue.updateValue(newColor.h);
 
-                        if (oldColor.s !== newColor.s) characteristicSaturation.updateValue(newColor.h);
+                        if (oldColor.s !== newColor.s) characteristicSaturation.updateValue(newColor.s);
 
                         if (characteristicColorTemperature.value !== 0) characteristicColorTemperature.updateValue(0);
 


### PR DESCRIPTION
## Problem

In `RGBTWLightAccessory`, the device-change handler for color mode updates the HomeKit **Saturation** characteristic with the new **hue** value:

```js
if (oldColor.s !== newColor.s) characteristicSaturation.updateValue(newColor.h);
```

Whenever a color change originates outside HomeKit (e.g. the Tuya app or an automation changes the color), HomeKit's saturation state is set to the hue value — e.g. a saturated red (h=0, s=100) reports saturation 0, and any hue above 100 sets an out-of-range saturation. The Home app then shows the wrong color, and subsequent partial updates (hue-only or saturation-only changes from HomeKit) are computed from that corrupted cached state.

## Fix

One character: update the characteristic with `newColor.s`.