### PR TITLE
fix: don't misreport discover-handler exceptions as parse failures

### DIFF
--- a/lib/TuyaDiscovery.js
+++ b/lib/TuyaDiscovery.js
@@ -169,14 +169,9 @@ class TuyaDiscovery extends EventEmitter {
 
     if (!decryptedMsg) decryptedMsg = cleanMsg.toString('utf8');
 
+    let result;
     try {
-      const result = JSON.parse(decryptedMsg);
-      if (result && result.gwId && result.ip) this._onDiscover(result);
-      else
-        this.log.error(
-          `Discovery - UDP from ${info.address}:${port} decrypted`,
-          cleanMsg.toString('hex')
-        );
+      result = JSON.parse(decryptedMsg);
     } catch (ex) {
       this.log.error(
         `Discovery - Failed to parse discovery response on port ${port}: ${decryptedMsg}`
@@ -185,6 +180,25 @@ class TuyaDiscovery extends EventEmitter {
         `Discovery - Failed to parse discovery raw message on port ${port}: ${msg.toString(
           'hex'
         )}`
+      );
+      return;
+    }
+
+    if (result && result.gwId && result.ip) {
+      // Keep 'discover' listener exceptions out of the JSON-parse handling
+      // above — they used to be misreported as parse failures, hiding the
+      // real stack trace.
+      try {
+        this._onDiscover(result);
+      } catch (ex) {
+        this.log.error(
+          `Discovery - discover handler failed for ${result.gwId}: ${ex.stack}`
+        );
+      }
+    } else {
+      this.log.error(
+        `Discovery - UDP from ${info.address}:${port} decrypted`,
+        cleanMsg.toString('hex')
       );
     }
   }
@@ -256,19 +270,31 @@ class TuyaDiscovery extends EventEmitter {
       }
 
       // Parse JSON and handle discovery
+      let result;
       try {
-        const result = JSON.parse(jsonPayload);
-        if (result && result.gwId && result.ip) {
-          this._onDiscover(result);
-        } else {
-          this.log.error(
-            `Discovery - Invalid v3.5 discovery data from ${info.address}:${port}`,
-            jsonPayload
-          );
-        }
+        result = JSON.parse(jsonPayload);
       } catch (ex) {
         this.log.error(
           `Discovery - Failed to parse v3.5 discovery response from ${info.address}:${port}: ${jsonPayload}`
+        );
+        return;
+      }
+
+      if (result && result.gwId && result.ip) {
+        // Keep 'discover' listener exceptions out of the JSON-parse handling
+        // above — they used to be misreported as parse failures, hiding the
+        // real stack trace.
+        try {
+          this._onDiscover(result);
+        } catch (ex) {
+          this.log.error(
+            `Discovery - discover handler failed for ${result.gwId}: ${ex.stack}`
+          );
+        }
+      } else {
+        this.log.error(
+          `Discovery - Invalid v3.5 discovery data from ${info.address}:${port}`,
+          jsonPayload
         );
       }
     } catch (ex) {


### PR DESCRIPTION
An exception thrown by a `discover` event listener (e.g. accessory creation failing in the platform, as happens on Homebridge 2.x without #23) is caught by the JSON-parse `catch` block in `TuyaDiscovery._onDgramMessage` and logged as:

```
Discovery - Failed to parse discovery response on port 6667: {"ip":"...","gwId":"...",...}
```

…even though the JSON shown is perfectly valid. The real exception and its stack trace are swallowed, and the device is silently dropped. This made the Homebridge 2.x incompatibility (fixed by #23) very hard to diagnose — the log blamed the discovery packet instead of showing the `TypeError` from `getCategory`.

This PR parses the JSON in its own try/catch and wraps the `_onDiscover()` call separately, so listener exceptions are logged with their full stack. Applied to both the classic (55AA) and v3.5 (6699) code paths.