### PR TITLE
feat: powerOnDps option for SimpleLight/SimpleDimmer

### DIFF
--- a/lib/SimpleDimmerAccessory.js
+++ b/lib/SimpleDimmerAccessory.js
@@ -28,7 +28,7 @@ class SimpleDimmerAccessory extends BaseAccessory {
         const characteristicOn = service.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
             .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .on('set', this.setPower.bind(this));
 
         const characteristicBrightness = service.getCharacteristic(Characteristic.Brightness)
             .updateValue(this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]))
@@ -40,6 +40,16 @@ class SimpleDimmerAccessory extends BaseAccessory {
             if (changes.hasOwnProperty(this.dpBrightness) && this.convertBrightnessFromHomeKitToTuya(characteristicBrightness.value) !== changes[this.dpBrightness])
                 characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit(changes[this.dpBrightness]));
         });
+    }
+
+    setPower(value, callback) {
+        const dps = {[this.dpPower]: value};
+        // powerOnDps: extra datapoints asserted on every power-on, so devices
+        // exposed with reduced controls always return to a known mode (e.g.
+        // {"21": "white", "23": 0} for warm white). Already-correct values are
+        // skipped by setMultiState.
+        if (value && this.device.context.powerOnDps) Object.assign(dps, this.device.context.powerOnDps);
+        this.setMultiState(dps, callback);
     }
 
     getBrightness(callback) {

--- a/lib/SimpleLightAccessory.js
+++ b/lib/SimpleLightAccessory.js
@@ -27,12 +27,22 @@ class SimpleLightAccessory extends BaseAccessory {
         const characteristicOn = service.getCharacteristic(Characteristic.On)
             .updateValue(dps[this.dpPower])
             .on('get', this.getState.bind(this, this.dpPower))
-            .on('set', this.setState.bind(this, this.dpPower));
+            .on('set', this.setPower.bind(this));
 
         this.device.on('change', (changes, state) => {
             if (changes.hasOwnProperty(this.dpPower) && characteristicOn.value !== changes[this.dpPower]) characteristicOn.updateValue(changes[this.dpPower]);
             this.log.info('SimpleLight changed: ' + JSON.stringify(state));
         });
+    }
+
+    setPower(value, callback) {
+        const dps = {[this.dpPower]: value};
+        // powerOnDps: extra datapoints asserted on every power-on, so devices
+        // exposed with reduced controls always return to a known mode (e.g.
+        // {"21": "white", "23": 0} for warm white). Already-correct values are
+        // skipped by setMultiState.
+        if (value && this.device.context.powerOnDps) Object.assign(dps, this.device.context.powerOnDps);
+        this.setMultiState(dps, callback);
     }
 }
 


### PR DESCRIPTION
When a multi-mode device (e.g. an RGBCW light) is deliberately exposed with reduced controls as a `SimpleLight` or `SimpleDimmer`, nothing ever corrects its work mode if it drifts — a power cycle or another controller can leave it in a scene/color mode, and HomeKit's on/off just re-lights whatever was there.

This adds a `powerOnDps` device option: a map of extra datapoints asserted on every HomeKit power-on. Example — an RGBCW string light pinned to warm white:

```json
{
    "type": "SimpleDimmer",
    "dpPower": 20,
    "dpBrightness": 22,
    "minBrightness": 10,
    "scaleBrightness": 1000,
    "powerOnDps": {"21": "white", "23": 0}
}
```

Values that already match the cached device state are skipped by `setMultiState`, so steady-state power-ons send only the power DP.